### PR TITLE
fix: goroutine leak

### DIFF
--- a/butcher.go
+++ b/butcher.go
@@ -171,7 +171,7 @@ func (b *butcher[T]) task(ctx context.Context, j job[T]) (err error) {
 		ctx, cancel = context.WithTimeout(ctx, b.taskTimeout)
 		defer cancel()
 	}
-	errCh := make(chan error)
+	errCh := make(chan error, 1)
 	go func() {
 		errCh <- safelyRun(func() error {
 			return b.executor.Task(ctx, j.Payload)


### PR DESCRIPTION
fix: goroutine leak.

如果ctx结束，`errCh` 没有读取端了，那么goroutine就无法结束。